### PR TITLE
feat(ast): add the AST and parser for CMakeLists.txt files

### DIFF
--- a/cmakelib/ast/BUILD.bazel
+++ b/cmakelib/ast/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "ast.go",
+        "bindings.go",
+        "domain.go",
+        "eval.go",
+        "parser.go",
+    ],
+    importpath = "github.com/kythe/llvmbzlgen/cmakelib/ast",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmakelib/lexer:go_default_library",
+        "@com_github_alecthomas_participle//:go_default_library",
+        "@com_github_alecthomas_participle//lexer:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ast_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//cmakelib/lexer:go_default_library",
+        "@com_github_alecthomas_participle//:go_default_library",
+        "@com_github_alecthomas_participle//lexer:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
+)

--- a/cmakelib/ast/ast.go
+++ b/cmakelib/ast/ast.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/alecthomas/participle/lexer"
+)
+
+var identPattern = regexp.MustCompile(`[A-Za-z_]\w*`)
+
+// CMakeFile represents the root of a CMakeLists.txt AST and corresponds to:
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#source-files
+type CMakeFile struct {
+	Commands []CommandInvocation `( ( Space | Newline )* @@ ( Space | Newline )* )*`
+}
+
+// CommandInvocation is a top-level CMake command.
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#command-invocations
+type CommandInvocation struct {
+	Pos lexer.Position
+
+	Name      Ident        `Space* @Unquoted Space*`
+	Arguments ArgumentList `@@`
+}
+
+// ArgumentList is a parentheses-enclosed separated list of arguments.
+// It broadly corresponds to the arguments and separated_argument productions from:
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#command-invocations
+type ArgumentList struct {
+	Values []Argument `"(" @@? ((( Space | Newline )+ @@? ) | @@ )* ")"`
+}
+
+// Argument is a union-production for each of the CMake argument kinds.
+// See: https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#command-arguments
+type Argument struct {
+	Pos lexer.Position
+
+	ArgumentList     *ArgumentList     `@@`
+	QuotedArgument   *QuotedArgument   `| @@`
+	UnquotedArgument *UnquotedArgument `| @@`
+	BracketArgument  *BracketArgument  `| @@`
+}
+
+// BracketArgument is a [=*[<text>]=*]-enclosed argument corresponding to:
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#bracket-argument
+type BracketArgument struct {
+	Text string `BracketOpen @BracketContent? BracketClose`
+}
+
+// QuotedArgument is a simple quoted string, corresponding to:
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#quoted-argument
+type QuotedArgument struct {
+	Elements []QuotedElement `"\"" ( @@ )* "\""`
+}
+
+// QuotedElement is either a string of quoted text or a variable reference.
+type QuotedElement struct {
+	Ref  *VariableReference `@@`
+	Text string             `| @( Quoted | EscapeSequence | VarClose )+`
+}
+
+// UnquotedArgument is CMake's standed unquoted command argument:
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#unquoted-argument
+// Note: The unquoted_legacy production mentioned above is *not* supported.
+type UnquotedArgument struct {
+	Elements []UnquotedElement `@@ ( @@ )*`
+}
+
+// UnquotedElement is either a run of unquoted text or a variable reference.
+type UnquotedElement struct {
+	Ref  *VariableReference `@@`
+	Text string             `| @( Unquoted | EscapeSequence | VarClose )+`
+}
+
+// VariableReference is a possibly-nested CMake ${}-enclosed variable reference:
+// https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#variable-references
+// In order to capture the nature of these, they are embedded in the grammar rather than
+// being handled during evaluation.
+type VariableReference struct {
+	Pos lexer.Position
+
+	Domain   VarDomain         `@VarOpen`
+	Elements []VariableElement `@@ ( @@ )* "}"`
+}
+
+// VariableElement is either a run of text corresponding the a variable name
+// or a nested VariableReference.
+type VariableElement struct {
+	Text string             `@( Unquoted | Quoted )?`
+	Ref  *VariableReference `( @@ )?`
+}
+
+// Ident is a limited-alphabet string of unquoted text.
+// It is handled during capture to simplify the lexer and grammar.
+type Ident string
+
+// Capture captures a list of text values, checking that it is a valid identifier.
+func (i *Ident) Capture(values []string) error {
+	value := strings.Join(values, "")
+	if !identPattern.MatchString(value) {
+		return fmt.Errorf("invalid identifier: %s", value)
+	}
+	*i = Ident(value)
+	return nil
+}

--- a/cmakelib/ast/ast_test.go
+++ b/cmakelib/ast/ast_test.go
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/alecthomas/participle"
+	plex "github.com/alecthomas/participle/lexer"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/kythe/llvmbzlgen/cmakelib/lexer"
+)
+
+var positionType = reflect.TypeOf(plex.Position{})
+
+func ignorePosition() cmp.Option {
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		f, ok := p.Last().(cmp.StructField)
+		if !ok {
+			return false
+		}
+		return f.Name() == "Pos" && f.Type() == positionType
+	}, cmp.Ignore())
+}
+
+func parseVariableReference(input string) (*VariableReference, error) {
+	ref := &VariableReference{}
+	parser := participle.MustBuild(ref, participle.Lexer(lexer.New()))
+	if err := parser.ParseString(input, ref); err != nil {
+		return nil, err
+	}
+	return ref, nil
+}
+
+func parseUnquotedArgument(input string) (*UnquotedArgument, error) {
+	arg := &UnquotedArgument{}
+	parser := participle.MustBuild(arg, participle.Lexer(lexer.New()))
+	if err := parser.ParseString(input, arg); err != nil {
+		return nil, err
+	}
+	return arg, nil
+}
+
+func parseBracketArgument(input string) (*BracketArgument, error) {
+	arg := &BracketArgument{}
+	parser := participle.MustBuild(arg, participle.Lexer(lexer.New()))
+	if err := parser.ParseString(input, arg); err != nil {
+		return nil, err
+	}
+	return arg, nil
+}
+
+func parseQuotedArgument(input string) (*QuotedArgument, error) {
+	arg := &QuotedArgument{}
+	parser := participle.MustBuild(arg, participle.Lexer(lexer.New()))
+	if err := parser.ParseString(input, arg); err != nil {
+		return nil, err
+	}
+	return arg, nil
+}
+
+func parseArgumentList(input string) (*ArgumentList, error) {
+	arg := &ArgumentList{}
+	parser := participle.MustBuild(arg, participle.Lexer(lexer.New()))
+	if err := parser.ParseString(input, arg); err != nil {
+		return nil, err
+	}
+	return arg, nil
+}
+
+func parseCMakeFile(input string) (*CMakeFile, error) {
+	file, err := NewParser().ParseString(input)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func TestVariableReferences(t *testing.T) {
+	varRef := VariableReference{Elements: []VariableElement{{Text: "VAR"}}}
+	tests := map[string]VariableReference{
+		`${VAR}`:                       varRef,
+		`$ENV{VAR}`:                    {Domain: DomainEnv, Elements: varRef.Elements},
+		`${${VAR}}`:                    {Elements: []VariableElement{{Ref: &varRef}}},
+		`${pre_${VAR}_in_${VAR}_post}`: {Elements: []VariableElement{{"pre_", &varRef}, {"_in_", &varRef}, {Text: "_post"}}},
+		`${${VAR}_in_${VAR}}`:          {Elements: []VariableElement{{Ref: &varRef}, {"_in_", &varRef}}},
+	}
+	for input, expected := range tests {
+		root, err := parseVariableReference(input)
+		if err != nil {
+			t.Errorf("Error parsing %#v: %s", input, err)
+		} else if diff := cmp.Diff(*root, expected, ignorePosition()); diff != "" {
+			t.Errorf("Unexpected parse %#v:\n%s", input, diff)
+		}
+	}
+
+}
+
+func TestUnquotedArgument(t *testing.T) {
+	tests := map[string]UnquotedArgument{
+		`NoSpace`:            {Elements: []UnquotedElement{{Text: "NoSpace"}}},
+		`Escaped\ Space`:     {Elements: []UnquotedElement{{Text: `Escaped\ Space`}}},
+		`Escaped\;Semicolon`: {Elements: []UnquotedElement{{Text: `Escaped\;Semicolon`}}},
+		`${VAR}`:             {Elements: []UnquotedElement{{Ref: &VariableReference{Elements: []VariableElement{{Text: "VAR"}}}}}},
+		`$ENV`:               {Elements: []UnquotedElement{{Text: "$ENV"}}},
+		`Nested${VAR}Reference`: {Elements: []UnquotedElement{
+			{Text: "Nested"},
+			{Ref: &VariableReference{Elements: []VariableElement{{Text: "VAR"}}}},
+			{Text: "Reference"},
+		}},
+		// This is divided during evaluation, but is still a single argument.
+		`This;Divides;Into;Five;Arguments`: {Elements: []UnquotedElement{{Text: "This;Divides;Into;Five;Arguments"}}},
+	}
+	for input, expected := range tests {
+		root, err := parseUnquotedArgument(input)
+		if err != nil {
+			t.Errorf("Error parsing %#v: %s", input, err)
+		} else if diff := cmp.Diff(*root, expected, ignorePosition()); diff != "" {
+			t.Errorf("Unexpected parse %#v:\n%s", input, diff)
+		}
+	}
+}
+
+func TestBracketArgument(t *testing.T) {
+	tests := map[string]string{
+		`[[]]`:                         ``,                   // Empty
+		`[=[]=]`:                       ``,                   // Empty, non-empty delimiter.
+		`[=[${var}]=]`:                 `${var}`,             // Unevaluated variable reference.
+		`[===[content\n]]]=]]==]]===]`: `content\n]]]=]]==]`, // Unmatched delimiters.
+	}
+	for input, expected := range tests {
+		root, err := parseBracketArgument(input)
+		if err != nil {
+			t.Errorf("Error parsing %#v: %s", input, err)
+		} else if diff := cmp.Diff(root.Text, expected, ignorePosition()); diff != "" {
+			t.Errorf("Unexpected parse %#v:\n%s", input, diff)
+		}
+	}
+}
+
+func TestQuotedArgument(t *testing.T) {
+	tests := map[string]QuotedArgument{
+		`""`:               {},                                                  // Empty.
+		`"\n"`:             {Elements: []QuotedElement{{Text: `\n`}}},           // Newline.
+		`"\\n"`:            {Elements: []QuotedElement{{Text: `\\n`}}},          // Escaped newline.
+		"\"\n\"":           {Elements: []QuotedElement{{Text: "\n"}}},           // Literal newline.
+		`"regular text"`:   {Elements: []QuotedElement{{Text: "regular text"}}}, // Boring regular text.
+		"\"cont\\\ninue\"": {Elements: []QuotedElement{{Text: "cont\\\ninue"}}}, // Escaped continuation.
+		`"ident"`:          {Elements: []QuotedElement{{Text: `ident`}}},        // Thing that could be an identifier.
+		`"\${var}"`:        {Elements: []QuotedElement{{Text: `\${var}`}}},      // Escaped variable reference.
+		`"$ENV"`:           {Elements: []QuotedElement{{Text: "$ENV"}}},         // String that looks like a varible reference.
+		// Variable reference.
+		`"${var}"`: {Elements: []QuotedElement{{Ref: &VariableReference{Elements: []VariableElement{{Text: "var"}}}}}},
+		// Environment variable reference.
+		`"$ENV{var}"`: {Elements: []QuotedElement{
+			{Ref: &VariableReference{Domain: DomainEnv, Elements: []VariableElement{{Text: "var"}}}},
+		}},
+		`"Nested${var}Reference"`: {Elements: []QuotedElement{
+			{Text: "Nested"},
+			{Ref: &VariableReference{Elements: []VariableElement{{Text: "var"}}}},
+			{Text: "Reference"},
+		}},
+	}
+	for input, expected := range tests {
+		root, err := parseQuotedArgument(input)
+		if err != nil {
+			t.Errorf("Error parsing %#v: %s", input, err)
+		} else if diff := cmp.Diff(*root, expected, ignorePosition()); diff != "" {
+			t.Errorf("Unexpected parse %#v:\n%s", input, diff)
+		}
+	}
+}
+
+func TestArgumentList(t *testing.T) {
+	tests := map[string]ArgumentList{
+		`()`:             {},
+		`(  )`:           {},
+		"(\n \n )":       {},
+		"(#comment\n)":   {},
+		"(#[[comment]])": {},
+		`(())`:           {Values: []Argument{{ArgumentList: &ArgumentList{}}}},
+		`(A()B)`: {Values: []Argument{
+			{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "A"}}}},
+			{ArgumentList: &ArgumentList{}},
+			{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "B"}}}},
+		}},
+		`(A (B AND NOT(C OR D)))`: {Values: []Argument{
+			{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "A"}}}},
+			{ArgumentList: &ArgumentList{Values: []Argument{
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "B"}}}},
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "AND"}}}},
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "NOT"}}}},
+				{ArgumentList: &ArgumentList{Values: []Argument{
+					{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "C"}}}},
+					{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "OR"}}}},
+					{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "D"}}}},
+				}}},
+			}}},
+		},
+		},
+	}
+	for input, expected := range tests {
+		root, err := parseArgumentList(input)
+		if err != nil {
+			t.Errorf("Error parsing %#v: %s", input, err)
+		} else if diff := cmp.Diff(*root, expected, ignorePosition()); diff != "" {
+			t.Errorf("Unexpected parse %#v:\n%s", input, diff)
+		}
+	}
+}
+
+func TestCMakeFile(t *testing.T) {
+	tests := map[string]CMakeFile{
+		"directive(\nCOMMAND   )\n": {
+			[]CommandInvocation{{Name: "directive", Arguments: ArgumentList{Values: []Argument{
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "COMMAND"}}}},
+			}}}},
+		},
+		"directive(\nCOMMAND\n\n  )\n": {
+			[]CommandInvocation{{Name: "directive", Arguments: ArgumentList{Values: []Argument{
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "COMMAND"}}}},
+			}}}},
+		},
+		`directive(1234 Unquoted;List Nested${VAR}Ref "Quoted${VAR}Ref")`: {
+			[]CommandInvocation{{Name: "directive", Arguments: ArgumentList{Values: []Argument{
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "1234"}}}},
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{{Text: "Unquoted;List"}}}},
+				{UnquotedArgument: &UnquotedArgument{Elements: []UnquotedElement{
+					{Text: "Nested"},
+					{Ref: &VariableReference{Elements: []VariableElement{{Text: "VAR"}}}},
+					{Text: "Ref"},
+				}}},
+				{QuotedArgument: &QuotedArgument{Elements: []QuotedElement{
+					{Text: "Quoted"},
+					{Ref: &VariableReference{Elements: []VariableElement{{Text: "VAR"}}}},
+					{Text: "Ref"},
+				}}},
+			}}}},
+		},
+	}
+	for input, expected := range tests {
+		root, err := parseCMakeFile(input)
+		if err != nil {
+			t.Errorf("Error parsing %#v: %s", input, err)
+		} else if diff := cmp.Diff(*root, expected, ignorePosition()); diff != "" {
+			t.Errorf("Unexpected parse %#v:\n%s", input, diff)
+		}
+	}
+}

--- a/cmakelib/ast/bindings.go
+++ b/cmakelib/ast/bindings.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+// Bindings provides the AST with variable bindings in the current scope.
+// All interface functions are expected to return either the value currently
+// bound to the provided name or an empty string.
+type Bindings interface {
+	Get(string) string      // Returns the named CMake variable or the empty string.
+	GetCache(string) string // Returns the named CMake variable from the cache.
+	GetEnv(string) string   // Returns the named Environment variable.
+}

--- a/cmakelib/ast/domain.go
+++ b/cmakelib/ast/domain.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import "fmt"
+
+// Constants defining the recognized valid variable domains.
+const (
+	DomainDefault VarDomain = iota // The default (anonymous) domain.
+	DomainCache                    // CACHE variable references.
+	DomainEnv                      // ENV variable references.
+	DomainMake                     // Make variables.
+)
+
+// VarDomain represents one of CMake's variable scopes.
+type VarDomain int
+
+// Capture translates a sequence of values into the appropriate variable domain.
+func (d *VarDomain) Capture(values []string) error {
+	if len(values) > 1 {
+		return fmt.Errorf("invalid Domain values: %v", values)
+	}
+	value := values[0]
+	if len(value) > 0 && value[0] == '$' {
+		value = value[1 : len(value)-1]
+	}
+	switch value {
+	case "":
+		*d = DomainDefault
+	case "CACHE":
+		*d = DomainCache
+	case "ENV":
+		*d = DomainEnv
+	default:
+		return fmt.Errorf("invalid Domain: %s", value)
+	}
+	return nil
+}
+
+// String implements fmt.Stringer for VarDomain and returns a user-readable string for the domain.
+func (d VarDomain) String() string {
+	switch d {
+	case DomainDefault:
+		return "(default)"
+	case DomainEnv:
+		return "ENV"
+	case DomainCache:
+		return "CACHE"
+	case DomainMake:
+		return "(make)"
+	default:
+		panic("invalid domain")
+
+	}
+}

--- a/cmakelib/ast/eval.go
+++ b/cmakelib/ast/eval.go
@@ -93,7 +93,7 @@ func (a *BracketArgument) Eval(vars Bindings) []string {
 	return []string{a.Text}
 }
 
-// Eval recursively resolved variable references using vars and returns the result.
+// Eval recursively resolves variable references using vars and returns the result.
 func (v *VariableReference) Eval(vars Bindings) []string {
 	var name []string
 	for _, e := range v.Elements {
@@ -115,7 +115,7 @@ func (v *VariableReference) Eval(vars Bindings) []string {
 	return []string{get(strings.Join(name, ""))}
 }
 
-// Eval recursively resolved variable references using vars and returns the result.
+// Eval recursively resolves variable references using vars and returns the result.
 func (v *VariableElement) Eval(vars Bindings) []string {
 	parts := []string{v.Text}
 	if v.Ref != nil {

--- a/cmakelib/ast/eval.go
+++ b/cmakelib/ast/eval.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Eval uses the provided bindings to resolve any variable references and returns a slice
+// corresponding to the argument values.
+func (a *ArgumentList) Eval(vars Bindings) []string {
+	var values []string
+	for _, arg := range a.Values {
+		values = append(values, arg.Eval(vars)...)
+	}
+	return values
+}
+
+// Eval returns a slice of argument values after resolving variable references from vars.
+func (a *Argument) Eval(vars Bindings) []string {
+	switch {
+	case a.QuotedArgument != nil:
+		return a.QuotedArgument.Eval(vars)
+	case a.UnquotedArgument != nil:
+		return a.UnquotedArgument.Eval(vars)
+	case a.BracketArgument != nil:
+		return a.BracketArgument.Eval(vars)
+	case a.ArgumentList != nil:
+		// Include the parens, but only for nested argument lists.
+		values := []string{"("}
+		values = append(values, a.ArgumentList.Eval(vars)...)
+		return append(values, ")")
+	}
+	panic("Missing concrete argument!")
+}
+
+// Eval returns a slice of argument values after resolving variable references from vars.
+// Semi-colon delimited lists are not separated.
+func (a *QuotedArgument) Eval(vars Bindings) []string {
+	var parts []string
+	for _, e := range a.Elements {
+		parts = append(parts, e.Eval(vars)...)
+	}
+	return []string{strings.Join(parts, "")}
+}
+
+// Eval returns a slice of values after resolving variable references using vars.
+func (e *QuotedElement) Eval(vars Bindings) []string {
+	if e.Ref != nil {
+		return e.Ref.Eval(vars)
+	}
+	// TODO(shahms): Deal with escape sequences.
+	return []string{e.Text}
+}
+
+// Eval returns a slice of argument values after resolving variable references from vars.
+// Semi-colon delimited lists are separated.
+func (a *UnquotedArgument) Eval(vars Bindings) []string {
+	var parts []string
+	for _, e := range a.Elements {
+		parts = append(parts, e.Eval(vars)...)
+	}
+	return []string{strings.Join(parts, "")}
+}
+
+// Eval returns a slice of values after evaluating escape sequences
+// and splitting on semicolons.
+func (e *UnquotedElement) Eval(vars Bindings) []string {
+	if e.Ref != nil {
+		return e.Ref.Eval(vars)
+	}
+	// TODO(shahms): Deal with escape sequences and lists.
+	return []string{e.Text}
+}
+
+// Eval returns a slice of values for the text of the argument.
+func (a *BracketArgument) Eval(vars Bindings) []string {
+	return []string{a.Text}
+}
+
+// Eval recursively resolved variable references using vars and returns the result.
+func (v *VariableReference) Eval(vars Bindings) []string {
+	var name []string
+	for _, e := range v.Elements {
+		name = append(name, e.Eval(vars)...)
+	}
+	var get func(string) string
+	switch v.Domain {
+	case DomainDefault:
+		get = vars.Get
+	case DomainCache:
+		get = vars.GetCache
+	case DomainEnv:
+		get = vars.GetEnv
+	case DomainMake:
+		fallthrough
+	default:
+		panic(fmt.Sprintf("unrecognized domain: %#v", v.Domain))
+	}
+	return []string{get(strings.Join(name, ""))}
+}
+
+// Eval recursively resolved variable references using vars and returns the result.
+func (v *VariableElement) Eval(vars Bindings) []string {
+	parts := []string{v.Text}
+	if v.Ref != nil {
+		for _, p := range v.Ref.Eval(vars) {
+			parts = append(parts, p)
+		}
+	}
+	return []string{strings.Join(parts, "")}
+}

--- a/cmakelib/ast/parser.go
+++ b/cmakelib/ast/parser.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"io"
+
+	"github.com/alecthomas/participle"
+	"github.com/kythe/llvmbzlgen/cmakelib/lexer"
+)
+
+// Parser parses CMake-style files following (most of) the grammar
+// defined at https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html
+type Parser struct {
+	p *participle.Parser
+}
+
+// NewParser constructs a new parser for CMakeLists-style files.
+func NewParser() *Parser {
+	return &Parser{participle.MustBuild(&CMakeFile{}, participle.Lexer(lexer.New()))}
+}
+
+// Parse reads a CMakeLists.txt file from r and parses it into an AST.
+func (p *Parser) Parse(r io.Reader) (*CMakeFile, error) {
+	cmf := &CMakeFile{}
+	return cmf, p.p.Parse(r, cmf)
+}
+
+// ParseString reads a CMakeLists.txt file from string s and parses it into an AST.
+func (p *Parser) ParseString(s string) (*CMakeFile, error) {
+	cmf := &CMakeFile{}
+	return cmf, p.p.ParseString(s, cmf)
+}
+
+// ParseBytes reads a CMakeLists.txt file from byte slice b and parses it into an AST.
+func (p *Parser) ParseBytes(b []byte) (*CMakeFile, error) {
+	cmf := &CMakeFile{}
+	return cmf, p.p.ParseBytes(b, cmf)
+}
+
+// String returns a string corresponding to the CMakeLists grammar.
+func (p *Parser) String() string {
+	return p.p.String()
+}


### PR DESCRIPTION
The actual parser and AST, build on the previously submitted lexer.  This lacks support for some things which aren't used in LLVM's more modern CMakeLists.txt files, but is otherwise handles the important parts of CMake's "grammar".

Due to some of the constraints of the parser generator library the AST isn't quite as compact as it could be, but works pretty well.