### PR TITLE
include support for unquoted delimited lists during evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bazel-*
+generated_cmake_targets.bzl
+generated_llvm_build_targets.bzl

--- a/cmakelib/ast/eval.go
+++ b/cmakelib/ast/eval.go
@@ -146,9 +146,9 @@ func replaceEscapes(text string) string {
 	})
 }
 
-// splitSemicolon splits the provided text on non-escaped semi-colons.
+// splitAndUnescape splits the provided text on non-escaped semi-colons and replaces escape sequences.
 func splitAndUnescape(text string) []string {
-	start := 0
+	var start int
 	var result []string
 	for _, m := range splitPattern.FindAllStringIndex(text, -1) {
 		result = append(result, replaceEscapes(text[start:m[1]-1]))

--- a/cmakelib/ast/eval.go
+++ b/cmakelib/ast/eval.go
@@ -18,7 +18,13 @@ package ast
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+)
+
+var (
+	escapePattern = regexp.MustCompile(`\\.`)
+	splitPattern  = regexp.MustCompile(`^;|[^\\];`)
 )
 
 // Eval uses the provided bindings to resolve any variable references and returns a slice
@@ -56,7 +62,7 @@ func (a *QuotedArgument) Eval(vars Bindings) []string {
 	for _, e := range a.Elements {
 		parts = append(parts, e.Eval(vars)...)
 	}
-	return []string{strings.Join(parts, "")}
+	return []string{replaceEscapes(strings.Join(parts, ""))}
 }
 
 // Eval returns a slice of values after resolving variable references using vars.
@@ -64,7 +70,6 @@ func (e *QuotedElement) Eval(vars Bindings) []string {
 	if e.Ref != nil {
 		return e.Ref.Eval(vars)
 	}
-	// TODO(shahms): Deal with escape sequences.
 	return []string{e.Text}
 }
 
@@ -75,7 +80,7 @@ func (a *UnquotedArgument) Eval(vars Bindings) []string {
 	for _, e := range a.Elements {
 		parts = append(parts, e.Eval(vars)...)
 	}
-	return []string{strings.Join(parts, "")}
+	return splitAndUnescape(strings.Join(parts, ""))
 }
 
 // Eval returns a slice of values after evaluating escape sequences
@@ -84,7 +89,6 @@ func (e *UnquotedElement) Eval(vars Bindings) []string {
 	if e.Ref != nil {
 		return e.Ref.Eval(vars)
 	}
-	// TODO(shahms): Deal with escape sequences and lists.
 	return []string{e.Text}
 }
 
@@ -124,4 +128,31 @@ func (v *VariableElement) Eval(vars Bindings) []string {
 		}
 	}
 	return []string{strings.Join(parts, "")}
+}
+
+// replaceEscapes replaces escape sequences in text with the appropriate value.
+func replaceEscapes(text string) string {
+	return escapePattern.ReplaceAllStringFunc(text, func(m string) string {
+		switch m[1] {
+		case 'n':
+			return "\n"
+		case 'r':
+			return "\r"
+		case 't':
+			return "\t"
+		default:
+			return m[1:]
+		}
+	})
+}
+
+// splitSemicolon splits the provided text on non-escaped semi-colons.
+func splitAndUnescape(text string) []string {
+	start := 0
+	var result []string
+	for _, m := range splitPattern.FindAllStringIndex(text, -1) {
+		result = append(result, replaceEscapes(text[start:m[1]-1]))
+		start = m[1]
+	}
+	return append(result, replaceEscapes(text[start:len(text)]))
 }

--- a/cmakelib/bindings/bindings.go
+++ b/cmakelib/bindings/bindings.go
@@ -81,7 +81,7 @@ func (m *Mapping) Get(key string) string {
 	return m.GetCache(key)
 }
 
-// GetCache returns the associated value from the variable cache.
+// GetCache returns the associated value from the variable cache or an empty string if not found.
 func (m *Mapping) GetCache(key string) string {
 	val, ok := m.cache[key]
 	if ok {

--- a/cmakelib/bindings/bindings.go
+++ b/cmakelib/bindings/bindings.go
@@ -22,12 +22,13 @@ import "log"
 
 // Mapping is a stack of map[string]string for CMake variables.
 type Mapping struct {
-	vs []map[string]string
+	vs    []map[string]string
+	cache map[string]string
 }
 
 // New returns a new, empty, variable stack.
 func New() *Mapping {
-	m := &Mapping{}
+	m := &Mapping{cache: make(map[string]string)}
 	m.Push()
 	return m
 }
@@ -59,6 +60,12 @@ func (m *Mapping) SetParent(key, value string) {
 	}
 }
 
+// SetCache sets a key to a particular value in CACHE scope.
+// Setting a key to the empty string is equivalent to deleting it, in accordance with CMake semantics.
+func (m *Mapping) SetCache(key, value string) {
+	m.cache[key] = value
+}
+
 // Get looks from the current scope up to find the nearest value for key.
 // If they key is absent, returns the empty string.
 // This matches the semantics of CMake variable lookup.
@@ -74,8 +81,12 @@ func (m *Mapping) Get(key string) string {
 	return m.GetCache(key)
 }
 
-// GetCache returns the associated value from the variable cache (not implemented).
+// GetCache returns the associated value from the variable cache.
 func (m *Mapping) GetCache(key string) string {
+	val, ok := m.cache[key]
+	if ok {
+		return val
+	}
 	return ""
 }
 

--- a/tools/cmaketobzl/cmaketobzl.go
+++ b/tools/cmaketobzl/cmaketobzl.go
@@ -333,7 +333,6 @@ func (e *eval) exitDirectory(path string) error {
 
 // PrintCommand writes the given command to the configured StarlarkWriter.
 func (e *eval) PrintCommand(command *ast.CommandInvocation) error {
-	//log.Println(command.Name, command.Arguments.Eval(e.v))
 	return e.w.WriteCommand(string(command.Name), writer.ArgumentLiterals(command.Arguments.Eval(e.v)))
 }
 

--- a/tools/cmaketobzl/cmaketobzl.go
+++ b/tools/cmaketobzl/cmaketobzl.go
@@ -67,7 +67,8 @@ type eval struct {
 
 	w    *writer.StarlarkWriter
 	v    *bindings.Mapping
-	path []string
+	root bzlpath.Path
+	path bzlpath.Path
 }
 
 type options struct {
@@ -144,14 +145,14 @@ func (e *eval) parseFile(path string) (*ast.CMakeFile, error) {
 }
 
 // walk evaluates all of the provided CMakeLists.txt files into the body of a single Starlark macro..
-func (e *eval) walk(paths []string) error {
+func (e *eval) walk(paths []bzlpath.Path) error {
 	if err := e.w.BeginMacro(e.o.macroName); err != nil {
 		return err
 	}
-	root, paths := bzlpath.SplitCommonRootString(paths)
-	e.path = append(e.path, root)
+	root, paths := bzlpath.SplitCommonRoot(paths)
+	e.root = root
 	for _, p := range paths {
-		if err := e.AddSubdirectory(p); err != nil {
+		if err := e.AddSubdirectory(p.String()); err != nil {
 			return err
 		}
 	}
@@ -244,9 +245,10 @@ func (e *eval) setVariable(args []string) {
 	switch {
 	case len(args) > 0 && args[len(args)-1] == "PARENT_SCOPE":
 		e.v.SetParent(key, strings.Join(args[0:len(args)-1], ";"))
-		// When setting CACHE variables, the option can occur in either position -3 or -4 due to the optional FORCE parameter.
-	case len(args) >= 3 && args[len(args)-3] == "CACHE", len(args) >= 4 && args[len(args)-4] == "CACHE":
-		log.Println("Ignoring set of CACHE variable: ", key)
+	case len(args) >= 3 && args[len(args)-3] == "CACHE":
+		e.v.SetCache(key, strings.Join(args[:len(args)-3], ";"))
+	case len(args) >= 4 && args[len(args)-4] == "CACHE": // FORCE
+		e.v.SetCache(key, strings.Join(args[:len(args)-4], ";"))
 	default:
 		e.v.Set(key, strings.Join(args, ";"))
 	}
@@ -263,7 +265,7 @@ func (e *eval) unsetVariable(args []string) {
 	case len(args) == 2 && args[1] == "PARENT_SCOPE":
 		e.v.SetParent(args[0], "")
 	case len(args) == 2 && args[1] == "CACHE":
-		log.Println("Ignoring unset of CACHE variable: ", args[0])
+		e.v.SetCache(args[0], "")
 	default:
 		log.Println("Ignoring invalid unset command")
 	}
@@ -274,7 +276,7 @@ func (e *eval) AddSubdirectory(dirpath string) error {
 	if err := e.enterDirectory(dirpath); err != nil {
 		return err
 	}
-	file, err := e.parseFile(path.Join(path.Join(e.path...), "CMakeLists.txt"))
+	file, err := e.parseFile(path.Join(e.root.String(), e.path.String(), "CMakeLists.txt"))
 	if err != nil {
 		return err
 	}
@@ -294,9 +296,16 @@ func (e *eval) AddSubdirectory(dirpath string) error {
 	return e.exitDirectory(dirpath)
 }
 
-// CurrentDirectory returns the project-rooted path currently being traversed.
+// ProjectRoot returns the path prefix for forming project-rooted absolute paths.
+func (e *eval) ProjectRoot() string {
+	// Use a fixed prefix so that paths formed by simple string concatenation don't
+	// start with '//' which is often treated specially.
+	return "/root"
+}
+
+// CurrentDirectory returns the relative, project-rooted path currently being traversed.
 func (e *eval) CurrentDirectory() string {
-	return "/" + path.Join(e.path[1:]...)
+	return path.Join(e.path...)
 }
 
 // enterDirectory pushes a new directory onto the stack, setting up necessary state, etc.
@@ -306,8 +315,8 @@ func (e *eval) enterDirectory(dirpath string) error {
 	}
 	e.v.Push()
 	e.path = append(e.path, dirpath)
-	e.v.Set("CMAKE_CURRENT_SOURCE_DIR", e.CurrentDirectory())
-	e.v.Set("CMAKE_CURRENT_BINARY_DIR", e.CurrentDirectory())
+	e.v.Set("CMAKE_CURRENT_SOURCE_DIR", path.Join(e.ProjectRoot(), e.CurrentDirectory()))
+	e.v.Set("CMAKE_CURRENT_BINARY_DIR", path.Join(e.ProjectRoot(), e.CurrentDirectory()))
 	return nil
 }
 
@@ -324,18 +333,13 @@ func (e *eval) exitDirectory(path string) error {
 
 // PrintCommand writes the given command to the configured StarlarkWriter.
 func (e *eval) PrintCommand(command *ast.CommandInvocation) error {
+	//log.Println(command.Name, command.Arguments.Eval(e.v))
 	return e.w.WriteCommand(string(command.Name), writer.ArgumentLiterals(command.Arguments.Eval(e.v)))
 }
 
 func main() {
 	flag.Parse()
 	eval := NewEvaluator(os.Stdout,
-		DefineVars(map[string]string{
-			"LLVM_MAIN_INCLUDE_DIR": "/include",
-			"LLVM_INCLUDE_DIR":      "/include",
-			"CLANG_SOURCE_DIR":      "/tools/clang",
-			"CLANG_BINARY_DIR":      "/tools/clang",
-		}),
 		ExcludePaths(Matching(`(^|/)(unittests|examples|cmake)($|/)`)),
 		RecurseCommands(Matching(`add(_\w+)?_subdirectory`)),
 		PrintCommands(Matching("^("+strings.Join([]string{
@@ -343,7 +347,7 @@ func main() {
 			"add_llvm_library", "add_clang_library", "add_llvm_target",
 			"add_tablegen", "tablegen", "clang_diag_gen", "clang_tablegen", "add_public_tablegen_target",
 		}, "|")+")$")))
-	if err := eval.walk(flag.Args()); err != nil {
+	if err := eval.walk(bzlpath.ToPaths(flag.Args())); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/writer/starlark_test.go
+++ b/writer/starlark_test.go
@@ -103,7 +103,7 @@ func TestReservedWord(t *testing.T) {
 	if err := writer.EndMacro(); err != nil {
 		t.Fatal("Unpexpected error ending macro: ", err)
 	}
-	expected := "def return_(ctx):\n    return ctx\n"
+	const expected = "def return_(ctx):\n    return ctx\n"
 	if diff := cmp.Diff(expected, b.String()); diff != "" {
 		t.Error("Unexpected writer output:\n", diff)
 	}

--- a/writer/starlark_test.go
+++ b/writer/starlark_test.go
@@ -16,7 +16,7 @@ func TestEmptyMacro(t *testing.T) {
 	if err := writer.EndMacro(); err != nil {
 		t.Fatal("Unpexpected error ending macro: ", err)
 	}
-	if diff := cmp.Diff("def hello_world(ctx):\n    pass\n", b.String()); diff != "" {
+	if diff := cmp.Diff("def hello_world(ctx):\n    return ctx\n", b.String()); diff != "" {
 		t.Error("Unexpected writer output:\n", diff)
 	}
 }
@@ -42,7 +42,7 @@ func TestDirectoryBuffering(t *testing.T) {
 	if err := writer.EndMacro(); err != nil {
 		t.Fatal("Unpexpected error ending macro: ", err)
 	}
-	if diff := cmp.Diff("def hello_world(ctx):\n    pass\n", b.String()); diff != "" {
+	if diff := cmp.Diff("def hello_world(ctx):\n    return ctx\n", b.String()); diff != "" {
 		t.Error("Unexpected writer output:\n", diff)
 	}
 }
@@ -68,7 +68,8 @@ func TestCommandWriting(t *testing.T) {
 	expected := "def hello_world(ctx):\n" +
 		"    ctx = ctx.push_directory(ctx, \"this/is/a/path\")\n" +
 		"    ctx.run(ctx, \"with\", \"args\")\n" +
-		"    ctx = ctx.pop_directory(ctx)\n"
+		"    ctx = ctx.pop_directory(ctx)\n" +
+		"    return ctx\n"
 	if diff := cmp.Diff(expected, b.String()); diff != "" {
 		t.Error("Unexpected writer output:\n", diff)
 	}
@@ -102,7 +103,7 @@ func TestReservedWord(t *testing.T) {
 	if err := writer.EndMacro(); err != nil {
 		t.Fatal("Unpexpected error ending macro: ", err)
 	}
-	expected := "def return_(ctx):\n    pass\n"
+	expected := "def return_(ctx):\n    return ctx\n"
 	if diff := cmp.Diff(expected, b.String()); diff != "" {
 		t.Error("Unexpected writer output:\n", diff)
 	}


### PR DESCRIPTION
Also support `set(... CACHE)` and `get(... CACHE)` by just doing so locally.

These changes enable switching to using llvmbzlgen'd targets in Kythe (a PR which is forthcoming).